### PR TITLE
Re-assign 0x8000000f  to Gapcoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -43,7 +43,7 @@ index | hexa       | symbol | coin
 12    | 0x8000000c | NBT    | NuBits
 13    | 0x8000000d | MZC    | Mazacoin
 14    | 0x8000000e | VIA    | Viacoin
-15    | 0x8000000f | XCH    | ClearingHouse
+15    | 0x8000000f | GAP    | Gapcoin (https://github.com/gapcoin-project/gapcoin
 16    | 0x80000010 | RBY    | Rubycoin
 17    | 0x80000011 | GRS    | Groestlcoin
 18    | 0x80000012 | DGC    | Digitalcoin


### PR DESCRIPTION
Would like to re-use ClearingHouse (XCH)  as it has been extinct for several years (https://bitcointalk.org/index.php?topic=734674.0, https://coinmarketcap.com/currencies/clearinghouse/markets/).
BIP39 commit ready for PR to Ian Coleman https://github.com/gapcoin-project/bip39/commit/3dc58b1a661d956a200d27c8554ca617b2015183